### PR TITLE
Add optional memory-budget reporting

### DIFF
--- a/source/Format.cpp
+++ b/source/Format.cpp
@@ -26,7 +26,7 @@ std::optional<std::string>
 			= Index / static_cast<std::float_t>(Width - 3);
 		if( !std::isfinite(Completion) )
 		{
-			Result += "\033[90m?";
+			Result += "\033[90m-";
 		}
 		else if( BarPhase <= Completion )
 		{

--- a/source/Format.cpp
+++ b/source/Format.cpp
@@ -12,7 +12,7 @@ using namespace Literals;
 std::optional<std::string>
 	FormatMeter(const std::size_t Width, const std::float_t Completion)
 {
-	if( !Width || Width < 3 || Completion < 0.0f || !std::isfinite(Completion) )
+	if( !Width || Width < 3 || Completion < 0.0f )
 	{
 		return std::nullopt;
 	}
@@ -24,7 +24,11 @@ std::optional<std::string>
 	{
 		const std::float_t BarPhase
 			= Index / static_cast<std::float_t>(Width - 3);
-		if( BarPhase <= Completion )
+		if( !std::isfinite(Completion) )
+		{
+			Result += "\033[90m?";
+		}
+		else if( BarPhase <= Completion )
 		{
 			if( BarPhase < 0.5f )
 			{

--- a/source/main.cpp
+++ b/source/main.cpp
@@ -398,7 +398,7 @@ bool FetchDevice(const vk::PhysicalDevice& PhysicalDevice)
 
 	Fetch.push_back(fmt::format(
 		"    VRAM: {}{}\033[0m / {}", PressureColor,
-		Format::FormatByteCount(MemUsed.value()),
+		MemUsed.has_value() ? Format::FormatByteCount(MemUsed.value()) : "???",
 		Format::FormatByteCount(MemTotal)
 	));
 


### PR DESCRIPTION
Only show the memory budget when `VK_EXT_memory_budget` is supported by the device.
Otherwise just indicate an unknown memory-budget value.