### PR TITLE
Refactor string formatting to `libfmt`

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -12,7 +12,10 @@ jobs:
   linux-build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          submodules: "recursive"
 
       - name: Setup Vulkan SDK
         uses: humbletim/setup-vulkan-sdk@v1.2.0
@@ -44,7 +47,10 @@ jobs:
   windows-build:
     runs-on: windows-latest
     steps:
-      - uses: actions/checkout@v2
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          submodules: "recursive"
 
       - name: Setup Vulkan SDK
         uses: humbletim/setup-vulkan-sdk@v1.2.0
@@ -73,7 +79,10 @@ jobs:
   macos-build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          submodules: "recursive"
 
       - name: Setup Vulkan SDK
         uses: humbletim/setup-vulkan-sdk@v1.2.0

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "externals/fmt"]
+	path = externals/fmt
+	url = git@github.com:fmtlib/fmt.git

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,7 +19,15 @@ elseif( CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang" )
 	endif()
 endif()
 
+#vulkan
 find_package( Vulkan REQUIRED )
+
+#fmt
+find_package(fmt QUIET)
+if( fmt_FOUND )
+else()
+	add_subdirectory( externals/fmt EXCLUDE_FROM_ALL )
+endif()
 
 add_executable(
 	vkfetch
@@ -37,4 +45,5 @@ target_link_libraries(
 	vkfetch
 	PRIVATE
 	Vulkan::Vulkan
+	fmt::fmt
 )

--- a/include/Format.hpp
+++ b/include/Format.hpp
@@ -3,7 +3,6 @@
 #include <cmath>
 #include <cstdint>
 #include <cstdio>
-#include <memory>
 #include <optional>
 #include <string>
 

--- a/include/Format.hpp
+++ b/include/Format.hpp
@@ -39,21 +39,6 @@ constexpr std::size_t operator""_PiB(unsigned long long int Size)
 
 } // namespace Literals
 
-template<typename... Args>
-std::optional<std::string>
-	FormatString(const std::string& Format, Args... Arguments)
-{
-	const std::size_t Size
-		= std::snprintf(nullptr, 0, Format.c_str(), Arguments...) + 1;
-	if( Size <= 0 )
-	{
-		return std::nullopt;
-	}
-	const auto Buffer = std::make_unique<char[]>(Size);
-	std::snprintf(Buffer.get(), Size, Format.c_str(), Arguments...);
-	return std::string(Buffer.get(), Buffer.get() + Size - 1);
-}
-
 std::optional<std::string>
 	FormatMeter(const std::size_t Width, const std::float_t Completion);
 

--- a/source/Format.cpp
+++ b/source/Format.cpp
@@ -2,6 +2,8 @@
 
 #include <VulkanConfig.hpp>
 
+#include <fmt/core.h>
+
 namespace Format
 {
 
@@ -50,7 +52,7 @@ std::optional<std::string>
 
 std::string FormatByteCount(std::size_t ByteCount)
 {
-	static std::array<const char*, 9> SizeUnits
+	static const std::array<const char*, 9> SizeUnits
 		= {{"Bytes", "KiB", "MiB", "GiB", "TiB", "PiB", "EiB", "ZiB", "YiB"}};
 
 	std::size_t Index;
@@ -61,28 +63,16 @@ std::string FormatByteCount(std::size_t ByteCount)
 			break;
 		ByteSize /= 1_KiB;
 	}
-	const std::size_t Size
-		= std::snprintf(nullptr, 0, "%.3f %s", ByteSize, SizeUnits.at(Index))
-		+ 1;
-	const auto Buffer = std::make_unique<char[]>(Size);
-	std::snprintf(Buffer.get(), Size, "%.3f %s", ByteSize, SizeUnits.at(Index));
-	return std::string(Buffer.get(), Buffer.get() + Size - 1);
+
+	return fmt::format("{:.3f} {}", ByteSize, SizeUnits.at(Index));
 }
 
 std::string FormatVersion(std::uint32_t Version)
 {
-	const std::size_t Size
-		= std::snprintf(
-			  nullptr, 0, "%u.%u.%u", VK_VERSION_MAJOR(Version),
-			  VK_VERSION_MINOR(Version), VK_VERSION_PATCH(Version)
-		  )
-		+ 1;
-	const auto Buffer = std::make_unique<char[]>(Size);
-	std::snprintf(
-		Buffer.get(), Size, "%u.%u.%u", VK_VERSION_MAJOR(Version),
-		VK_VERSION_MINOR(Version), VK_VERSION_PATCH(Version)
+	return fmt::format(
+		"{}.{}.{}", VK_VERSION_MAJOR(Version), VK_VERSION_MINOR(Version),
+		VK_VERSION_PATCH(Version)
 	);
-	return std::string(Buffer.get(), Buffer.get() + Size - 1);
 }
 
 std::string ReplaceString(

--- a/source/main.cpp
+++ b/source/main.cpp
@@ -476,9 +476,9 @@ int main()
 	}
 	else
 	{
-		std::fprintf(
+		fmt::println(
 			stderr, "Error creating vulkan instance: {}\n",
-			vk::to_string(CreateResult.result).c_str()
+			vk::to_string(CreateResult.result)
 		);
 		return EXIT_FAILURE;
 	}

--- a/source/main.cpp
+++ b/source/main.cpp
@@ -356,7 +356,7 @@ bool FetchDevice(const vk::PhysicalDevice& PhysicalDevice)
 	));
 
 	Fetch.push_back(fmt::format(
-		"    {} %%{}% 3.2f\033[0m",
+		"    {} %{} 3.2f\033[0m",
 		Format::FormatMeter(30, MemoryPressure).value(), PressureColor,
 		MemoryPressure * 100.0f
 	));

--- a/source/main.cpp
+++ b/source/main.cpp
@@ -308,7 +308,7 @@ bool FetchDevice(const vk::PhysicalDevice& PhysicalDevice)
 
 	Fetch.push_back(fmt::format(
 		"\033[1m{}\033[0m : {}", DeviceProperties.properties.deviceName.data(),
-		vk::to_string(DeviceProperties.properties.deviceType).c_str()
+		vk::to_string(DeviceProperties.properties.deviceType)
 	));
 
 	Fetch.push_back(fmt::format(
@@ -328,7 +328,7 @@ bool FetchDevice(const vk::PhysicalDevice& PhysicalDevice)
 
 	Fetch.push_back(fmt::format(
 		"    API: \033[37m{}",
-		Format::FormatVersion(DeviceProperties.properties.apiVersion).c_str()
+		Format::FormatVersion(DeviceProperties.properties.apiVersion)
 	));
 
 	const std::float_t MemoryPressure
@@ -352,13 +352,12 @@ bool FetchDevice(const vk::PhysicalDevice& PhysicalDevice)
 
 	Fetch.push_back(fmt::format(
 		"    VRAM: {}{}\033[0m / {}", PressureColor,
-		Format::FormatByteCount(MemUsed).c_str(),
-		Format::FormatByteCount(MemTotal).c_str()
+		Format::FormatByteCount(MemUsed), Format::FormatByteCount(MemTotal)
 	));
 
 	Fetch.push_back(fmt::format(
 		"    {} %%{}% 3.2f\033[0m",
-		Format::FormatMeter(30, MemoryPressure).value().c_str(), PressureColor,
+		Format::FormatMeter(30, MemoryPressure).value(), PressureColor,
 		MemoryPressure * 100.0f
 	));
 
@@ -441,7 +440,7 @@ bool FetchDevice(const vk::PhysicalDevice& PhysicalDevice)
 
 		fmt::println(
 			" {:<{}}\033[0m {}", ArtLine, ArtWidth,
-			CurLine < Fetch.size() ? Fetch[CurLine].c_str() : ""
+			CurLine < Fetch.size() ? Fetch[CurLine] : ""
 		);
 	}
 	std::putchar('\n');

--- a/source/main.cpp
+++ b/source/main.cpp
@@ -6,6 +6,8 @@
 #include <optional>
 #include <span>
 
+#include <fmt/core.h>
+
 #include <VulkanConfig.hpp>
 #include <VulkanUtil.hpp>
 

--- a/source/main.cpp
+++ b/source/main.cpp
@@ -312,7 +312,7 @@ bool FetchDevice(const vk::PhysicalDevice& PhysicalDevice)
 	));
 
 	Fetch.push_back(fmt::format(
-		"    Device: \033[37m{}4x\033[0m : \033[37m{}4x\033[0m ({})",
+		"    Device: \033[37m{:04x}\033[0m : \033[37m{:04x}\033[0m ({})",
 		DeviceProperties.properties.deviceID,
 		DeviceProperties.properties.vendorID,
 		Vulkan::Util::VendorName(static_cast<Vulkan::Util::VendorID>(

--- a/source/main.cpp
+++ b/source/main.cpp
@@ -356,7 +356,7 @@ bool FetchDevice(const vk::PhysicalDevice& PhysicalDevice)
 	));
 
 	Fetch.push_back(fmt::format(
-		"    {} %{} 3.2f\033[0m",
+		"    {} % {}{:3.2f}\033[0m",
 		Format::FormatMeter(30, MemoryPressure).value(), PressureColor,
 		MemoryPressure * 100.0f
 	));

--- a/source/main.cpp
+++ b/source/main.cpp
@@ -183,8 +183,8 @@ bool VendorDetails<Vulkan::Util::VendorID::Nvidia>(
 			  .get<vk::PhysicalDeviceShaderSMBuiltinsPropertiesNV>();
 
 	// clang-format off
-	Fetch.push_back(Format::FormatString("    Streaming Multiprocessors:\033[37m %u", SMBuiltinsProperties.shaderSMCount).value());
-	Fetch.push_back(Format::FormatString("    Warps Per SM:\033[37m %u", SMBuiltinsProperties.shaderWarpsPerSM).value());
+	Fetch.push_back(fmt::format("    Streaming Multiprocessors:\033[37m {}", SMBuiltinsProperties.shaderSMCount));
+	Fetch.push_back(fmt::format("    Warps Per SM:\033[37m {}", SMBuiltinsProperties.shaderWarpsPerSM));
 	// clang-format on
 
 	static std::array ASCII_ART = std::to_array<const char*>({
@@ -236,19 +236,18 @@ bool VendorDetails<Vulkan::Util::VendorID::AMD>(
 		* ShaderCoreProperties.shaderArraysPerEngineCount
 		* ShaderCoreProperties.computeUnitsPerShaderArray;
 
-	Fetch.push_back(Format::FormatString(
-						"    Compute Units:\033[37m %u\033[0m / %u",
-						ActiveComputeUnits, TotalComputeUnits
-	)
-						.value());
+	Fetch.push_back(fmt::format(
+		"    Compute Units:\033[37m {}\033[0m / {}", ActiveComputeUnits,
+		TotalComputeUnits
+	));
 
 	// clang-format off
-	Fetch.push_back(Format::FormatString("    ShaderEngines:\033[37m %u", ShaderCoreProperties.shaderEngineCount).value());
-	Fetch.push_back(Format::FormatString("    ShaderArraysPerEngineCount:\033[37m %u", ShaderCoreProperties.shaderArraysPerEngineCount).value());
-	Fetch.push_back(Format::FormatString("    ComputeUnitsPerShaderArray:\033[37m %u", ShaderCoreProperties.computeUnitsPerShaderArray).value());
-	Fetch.push_back(Format::FormatString("    SimdPerComputeUnit:\033[37m %u", ShaderCoreProperties.simdPerComputeUnit).value());
-	Fetch.push_back(Format::FormatString("    WavefrontsPerSimd:\033[37m %u", ShaderCoreProperties.wavefrontsPerSimd).value());
-	Fetch.push_back(Format::FormatString("    WavefrontSize:\033[37m %u", ShaderCoreProperties.wavefrontSize).value());
+	Fetch.push_back(fmt::format("    ShaderEngines:\033[37m {}", ShaderCoreProperties.shaderEngineCount));
+	Fetch.push_back(fmt::format("    ShaderArraysPerEngineCount:\033[37m {}", ShaderCoreProperties.shaderArraysPerEngineCount));
+	Fetch.push_back(fmt::format("    ComputeUnitsPerShaderArray:\033[37m {}", ShaderCoreProperties.computeUnitsPerShaderArray));
+	Fetch.push_back(fmt::format("    SimdPerComputeUnit:\033[37m {}", ShaderCoreProperties.simdPerComputeUnit));
+	Fetch.push_back(fmt::format("    WavefrontsPerSimd:\033[37m {}", ShaderCoreProperties.wavefrontsPerSimd));
+	Fetch.push_back(fmt::format("    WavefrontSize:\033[37m {}", ShaderCoreProperties.wavefrontSize));
 	// clang-format on
 
 	static std::array ASCII_ART = std::to_array<const char*>({
@@ -307,42 +306,30 @@ bool FetchDevice(const vk::PhysicalDevice& PhysicalDevice)
 	FetchArt   Art   = {};
 	FetchStyle Style = {nullptr, nullptr, nullptr, nullptr};
 
-	Fetch.push_back(
-		Format::FormatString(
-			"\033[1m%s\033[0m : %s",
-			DeviceProperties.properties.deviceName.data(),
-			vk::to_string(DeviceProperties.properties.deviceType).c_str()
-		)
-			.value()
-	);
+	Fetch.push_back(fmt::format(
+		"\033[1m{}\033[0m : {}", DeviceProperties.properties.deviceName.data(),
+		vk::to_string(DeviceProperties.properties.deviceType).c_str()
+	));
 
-	Fetch.push_back(
-		Format::FormatString(
-			"    Device: \033[37m%04x\033[0m : \033[37m%04x\033[0m (%s)",
-			DeviceProperties.properties.deviceID,
-			DeviceProperties.properties.vendorID,
-			Vulkan::Util::VendorName(static_cast<Vulkan::Util::VendorID>(
-				DeviceProperties.properties.vendorID
-			))
-		)
-			.value()
-	);
+	Fetch.push_back(fmt::format(
+		"    Device: \033[37m{}4x\033[0m : \033[37m{}4x\033[0m ({})",
+		DeviceProperties.properties.deviceID,
+		DeviceProperties.properties.vendorID,
+		Vulkan::Util::VendorName(static_cast<Vulkan::Util::VendorID>(
+			DeviceProperties.properties.vendorID
+		))
+	));
 
-	Fetch.push_back(Format::FormatString(
-						"    Driver: \033[37m%s\033[0m : \033[37m%s\033[0m",
-						DeviceDriverProperties.driverName.data(),
-						DeviceDriverProperties.driverInfo.data()
-	)
-						.value());
+	Fetch.push_back(fmt::format(
+		"    Driver: \033[37m{}\033[0m : \033[37m{}\033[0m",
+		DeviceDriverProperties.driverName.data(),
+		DeviceDriverProperties.driverInfo.data()
+	));
 
-	Fetch.push_back(
-		Format::FormatString(
-			"    API: \033[37m%s",
-			Format::FormatVersion(DeviceProperties.properties.apiVersion)
-				.c_str()
-		)
-			.value()
-	);
+	Fetch.push_back(fmt::format(
+		"    API: \033[37m{}",
+		Format::FormatVersion(DeviceProperties.properties.apiVersion).c_str()
+	));
 
 	const std::float_t MemoryPressure
 		= MemUsed / static_cast<std::float_t>(MemTotal);
@@ -363,19 +350,17 @@ bool FetchDevice(const vk::PhysicalDevice& PhysicalDevice)
 		PressureColor = PressureColors[2];
 	}
 
-	Fetch.push_back(Format::FormatString(
-						"    VRAM: %s%s\033[0m / %s", PressureColor,
-						Format::FormatByteCount(MemUsed).c_str(),
-						Format::FormatByteCount(MemTotal).c_str()
-	)
-						.value());
+	Fetch.push_back(fmt::format(
+		"    VRAM: {}{}\033[0m / {}", PressureColor,
+		Format::FormatByteCount(MemUsed).c_str(),
+		Format::FormatByteCount(MemTotal).c_str()
+	));
 
-	Fetch.push_back(Format::FormatString(
-						"    %s %%%s% 3.2f\033[0m",
-						Format::FormatMeter(30, MemoryPressure).value().c_str(),
-						PressureColor, MemoryPressure * 100.0f
-	)
-						.value());
+	Fetch.push_back(fmt::format(
+		"    {} %%{}% 3.2f\033[0m",
+		Format::FormatMeter(30, MemoryPressure).value().c_str(), PressureColor,
+		MemoryPressure * 100.0f
+	));
 
 	switch( static_cast<Vulkan::Util::VendorID>(
 		DeviceProperties.properties.vendorID
@@ -439,27 +424,23 @@ bool FetchDevice(const vk::PhysicalDevice& PhysicalDevice)
 		// Convert '#" to reverse-video blocks
 		if( Style[0] )
 			ArtLine = Format::ReplaceString(
-				ArtLine, "#",
-				Format::FormatString("%s\033[7m \033[0m", Style[0]).value()
+				ArtLine, "#", fmt::format("{}\033[7m \033[0m", Style[0])
 			);
 		if( Style[1] )
 			ArtLine = Format::ReplaceString(
-				ArtLine, "$",
-				Format::FormatString("%s\033[7m \033[0m", Style[1]).value()
+				ArtLine, "$", fmt::format("{}\033[7m \033[0m", Style[1])
 			);
 		if( Style[2] )
 			ArtLine = Format::ReplaceString(
-				ArtLine, "%",
-				Format::FormatString("%s\033[7m \033[0m", Style[2]).value()
+				ArtLine, "%", fmt::format("{}\033[7m \033[0m", Style[2])
 			);
 		if( Style[3] )
 			ArtLine = Format::ReplaceString(
-				ArtLine, "&",
-				Format::FormatString("%s\033[7m \033[0m", Style[3]).value()
+				ArtLine, "&", fmt::format("{}\033[7m \033[0m", Style[3])
 			);
 
-		std::printf(
-			" %-*s\033[0m %s\n", ArtWidth, ArtLine.c_str(),
+		fmt::println(
+			" {:<{}}\033[0m {}", ArtLine, ArtWidth,
 			CurLine < Fetch.size() ? Fetch[CurLine].c_str() : ""
 		);
 	}
@@ -497,7 +478,7 @@ int main()
 	else
 	{
 		std::fprintf(
-			stderr, "Error creating vulkan instance: %s\n",
+			stderr, "Error creating vulkan instance: {}\n",
 			vk::to_string(CreateResult.result).c_str()
 		);
 		return EXIT_FAILURE;


### PR DESCRIPTION
No point re-implementing string formatting when `libfmt` is right there.